### PR TITLE
Fix @shared/schema module not found in production

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,4 @@
-import { type User, type InsertUser, type Group, type InsertGroup, type Message, type InsertMessage, type Command, type InsertCommand, type Statistics, type InsertStatistics, type BotStatus, type InsertBotStatus } from "@shared/schema";
+import { type User, type InsertUser, type Group, type InsertGroup, type Message, type InsertMessage, type Command, type InsertCommand, type Statistics, type InsertStatistics, type BotStatus, type InsertBotStatus } from "../shared/schema";
 import { randomUUID } from "crypto";
 
 export interface IStorage {

--- a/server/whatsapp-clean.ts
+++ b/server/whatsapp-clean.ts
@@ -7,17 +7,20 @@ let fetchLatestBaileysVersion: any;
 try {
   // Try modern import first
   const BaileysModule = await import('@whiskeysockets/baileys');
-  makeWASocket = BaileysModule.default;
-  DisconnectReason = BaileysModule.DisconnectReason;
-  useMultiFileAuthState = BaileysModule.useMultiFileAuthState;
-  fetchLatestBaileysVersion = BaileysModule.fetchLatestBaileysVersion;
+  // Handle both default export as a function or as an object containing the functions
+  const baileys = BaileysModule.default;
+  makeWASocket = typeof baileys === 'function' ? baileys : baileys.makeWASocket;
+  DisconnectReason = BaileysModule.DisconnectReason || baileys.DisconnectReason;
+  useMultiFileAuthState = BaileysModule.useMultiFileAuthState || baileys.useMultiFileAuthState;
+  fetchLatestBaileysVersion = BaileysModule.fetchLatestBaileysVersion || baileys.fetchLatestBaileysVersion;
 } catch (error) {
   // Fallback to require for compatibility
   const baileys = require('@whiskeysockets/baileys');
-  makeWASocket = baileys.default || baileys;
-  DisconnectReason = baileys.DisconnectReason;
-  useMultiFileAuthState = baileys.useMultiFileAuthState;
-  fetchLatestBaileysVersion = baileys.fetchLatestBaileysVersion;
+  const b = baileys.default || baileys;
+  makeWASocket = typeof b === 'function' ? b : b.makeWASocket;
+  DisconnectReason = b.DisconnectReason;
+  useMultiFileAuthState = b.useMultiFileAuthState;
+  fetchLatestBaileysVersion = b.fetchLatestBaileysVersion;
 }
 import type { 
   ConnectionState,


### PR DESCRIPTION
The application was failing to start in production because `esbuild` was leaving `@shared/schema` as an external import due to the `--packages=external` flag. Since the `@shared` path alias is not a real package and is not resolvable by Node.js at runtime, it caused an `ERR_MODULE_NOT_FOUND` error.

I have:
1. Changed the import in `server/storage.ts` to use a relative path, which allows `esbuild` to bundle it into the final output.
2. Improved the robustness of the `@whiskeysockets/baileys` import in `server/whatsapp-clean.ts` to handle cases where the default export might be an object containing the expected functions rather than the function itself.
3. Verified the fix by running `npm run build` and then starting the server with `node dist/index.js`, confirming that the API responds correctly.

---
*PR created automatically by Jules for task [2658952511691775276](https://jules.google.com/task/2658952511691775276) started by @Andresv27728*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module import handling for better compatibility and stability.

* **Refactor**
  * Updated internal import paths for better code organization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Andresv27728/Be/pull/2)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->